### PR TITLE
Added profile for Synergy

### DIFF
--- a/ufw-synergy
+++ b/ufw-synergy
@@ -1,0 +1,4 @@
+[Synergy]
+title=Syngery
+description=Synergy lets you easily share your mouse and keyboard between multiple computers on your desk
+ports=24800/tcp


### PR DESCRIPTION
"Synergy lets you easily share your mouse and keyboard between multiple computers on your desk" ‒[synergy-foss.org](http://synergy-foss.org/)

According to [this page](http://synergy2.sourceforge.net/trouble.html#problem3) the Synergy server requires port 24800/tcp to be open.

In ArchLinux, Synergy is a part of the official repositories [here](https://www.archlinux.org/packages/?name=synergy) and has a wiki page [here](https://wiki.archlinux.org/index.php/Synergy)
