### PR TITLE
Dropbox rule improvements

### DIFF
--- a/ufw-dropbox
+++ b/ufw-dropbox
@@ -1,4 +1,4 @@
 [Dropbox]
 title=Dropbox LAN Sync
 description=Dropbox is a free service that lets you bring your photos, docs, and videos anywhere and share them easily
-ports=17500/tcp
+ports=17500/tcp|17500/udp

--- a/ufw-dropbox
+++ b/ufw-dropbox
@@ -1,4 +1,4 @@
 [Dropbox]
-title=Dropbox
+title=Dropbox LAN Sync
 description=Dropbox is a free service that lets you bring your photos, docs, and videos anywhere and share them easily
 ports=17500/tcp


### PR DESCRIPTION
*  Change Dropbox rule title to reflect this is for Dropbox LAN Sync protocol (DB-LSP) only, and is not needed otherwise for Dropbox to function
*  Allow UDP port 17500, which is also needed for LAN sync peer discovery
Sources:
    * Protocol analysis: https://web.archive.org/web/20120502064502/http://geeklogs.posterous.com/dropbox-lan-sync-protocol
    * Wireshark dissector: https://github.com/wireshark/wireshark/blob/f4b0abc7296bbb431e64e31f85b24c29196c2ae4/epan/dissectors/packet-db-lsp.c#L272
    * or simply run `netstat -lupn | grep dropbox` while dropbox is running with LAN Sync enabled