### PR TITLE
add rule for megasync

### DIFF
--- a/ufw-megasync
+++ b/ufw-megasync
@@ -1,0 +1,4 @@
+[Megasync]
+title=Megasync
+description=Sync your files to your Mega account
+ports=6342/tcp|6342/udp


### PR DESCRIPTION
Megasync wasn't working when ufw was enabled. This seems to fix the problem. I found the port from discussion here: https://github.com/meganz/MEGAsync/issues/124