### PR TITLE
Add profiles for KDE Connect and LXD

### DIFF
--- a/ufw-kdeconnect
+++ b/ufw-kdeconnect
@@ -1,0 +1,4 @@
+[KDE Connect]
+title=KDE Connect
+description=KDE Connect enables your devices to communicate with each other
+ports=1714:1764/udp|1714:1764/tcp

--- a/ufw-lxd
+++ b/ufw-lxd
@@ -1,0 +1,4 @@
+[LXD]
+title=LXD
+description=LXD is a next generation system container manager
+ports=8443/tcp


### PR DESCRIPTION
This PR adds a profile for LXD (`8443/tcp`), and a profile for KDE Connect (`1714:1764/udp|1714:1764/tcp`) (see https://community.kde.org/KDEConnect#Troubleshooting).