### PR TITLE
Fix typo in Synergy title

### DIFF
--- a/ufw-synergy
+++ b/ufw-synergy
@@ -1,4 +1,4 @@
 [Synergy]
-title=Syngery
+title=Synergy
 description=Synergy lets you easily share your mouse and keyboard between multiple computers on your desk
 ports=24800/tcp


### PR DESCRIPTION
Just a typo I've noticed while looking at the files.